### PR TITLE
Update shard.yml to fix broken dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,4 +14,4 @@ license: MIT
 
 dependencies:
   cli:
-    github: amberframework/cli
+    github: mosop/cli


### PR DESCRIPTION
`amberframework/cli` which was a fork of `mosop/cli` exists no more. 
Luckily `mosop/cli` still does, and works with cracker. 